### PR TITLE
feat(impl): allow empty string for key mirror

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -2,12 +2,12 @@ import { createActions, standardActions } from "../src";
 
 const types = {
   FOO: {
-    BAR: 'BAR',
+    BAR: '',
     BAZ: standardActions(),
     FIZZ: {
-      BUZZ: standardActions(),
-    }
-  }
+      BUZZ: 'BUZZ',
+    },
+  },
 };
 
 const actionTypes = createActions<typeof types>(types);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ function createActionsHelper(actionKey: string, actions: string | StringMap): st
     return actions;
   }
   return Object.entries(actions).reduce((previous, [key, value]) => {
-    if (key === value) return { ...previous, [key]: createActionsHelper(actionKey, value) };
+    if (key === value || value === '') return { ...previous, [key]: createActionsHelper(actionKey, key) };
     let newKey = key;
     if (actionKey) {
       newKey = `${actionKey}/${key}`;


### PR DESCRIPTION
Allows for a simpler way to configure key mirrors:

Before:
```typescript
const types = {
  FOO: {
    BAR: 'BAR',
  },
};
```

After:
```typescript
const types = {
  FOO: {
    BAR: '',
  },
};
```

Both have the same output: `{ FOO: { BAR: 'FOO/BAR' } }`

