### PR TITLE
build: create .npmignore to reduce bundle size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# Files
+.eslintignore
+.eslintrc.js
+.gitignore
+.nvmrc
+.travis.yml
+jest.config.js
+tsconfig.json
+
+# Directories
+example/*
+src/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 cache: npm
-node_js:
-  - '10'
 env:
   global:
     - CC_TEST_REPORTER_ID=c68c045998880a2a495f56a10fa936818b9892af84e53ed4248a8714ca564da8


### PR DESCRIPTION
### Summary

Hi! 

I actually got a notification about some issue being closed in this repo 😄 and was surprised to be receiving notifications in the first place (did _not_ realize this repo was technically open-source, though probably not useful to anybody outside Groove).

However, I noticed something that I _think_ might help decrease the bundle size a little.

Note that I include the `src` directory as part of the set of ignored files because you only want the _build_ files to be published not the source files.

Hope ya'll are doing well!

#### With the `.npmignore`

![image](https://user-images.githubusercontent.com/8136030/94298882-d8dd8580-ff34-11ea-8080-0fe437b0d0de.png)

#### Without the `.npmignore`

![image](https://user-images.githubusercontent.com/8136030/94298938-ef83dc80-ff34-11ea-8615-450e3de6c973.png)

#### Bonus Item: Removed the `node_js` key in the `.travis.yml` so it uses the `.nvmrc` Node version when building in Travis

![image](https://user-images.githubusercontent.com/8136030/94299519-c6178080-ff35-11ea-98b6-826b07018548.png)

`#orthogonalorthogonalorthogonal`